### PR TITLE
Containerized the application for GCP Cloud Run + README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:16-alpine3.17
+
+WORKDIR /app
+
+COPY . .
+
+RUN npm install
+RUN npm rebuild node-sass
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,67 @@
+# Updating the deployment
+
+## Running the app in Cloud Run
+
+To deploy and run the image on Cloud Run, go to the GCP console.
+
+Open the project for this repository.
+
+Go to the Cloud Run service.
+
+Open the currently running service.
+
+Click on "Edit and deploy new revision"
+
+Amend the settings and / or select another image from the artifact registry
+
+**Ensure you add the `NODE_ENV` env variable with `production` as a value**
+
+Click `Deploy` at the bottom
+
+## Updating the image
+
+### 1. Find the image name
+
+We need to match the image tag currently used in the Artifact Registry.
+
+#### Option 1: In the console
+
+In the GCP console, inside the project that holds the image, open the Artifact Registry service. The image will be under the `docker-images` folder, and will contain the name of this repo `eq-v2-prototypes`.
+
+#### Option 2: In the terminal
+
+You can also deduct the name manually:
+
+```bash
+$ $LOCATION-docker.pkg.dev/$PROJECT-ID/$REPOSITORY/$IMAGE
+```
+
+More details in the [GCP documentation](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#tag)
+
+### 2. Build the new image locally
+
+```bash
+docker build . $imagename
+```
+
+### 3. Send the image to GCP Artifact Registry
+
+Ensure you are [authenticated to the repository in Docker](https://cloud.google.com/artifact-registry/docs/docker/pushing-and-pulling#auth).
+
+Then
+
+```bash
+docker push $imagename
+```
+
+# Running locally
+
+```bash
+docker-compose up
+```
+
+Then in the browser
+
+```bash
+localhost:3000
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3"
+
+services:
+  eq-v2-prototypes:
+    image: onsdigital/eq-v2-prototypes:latest
+    build: ./
+    restart: always
+    ports:
+      - "3000:3000"


### PR DESCRIPTION
- App was deployed with Cloud Run to a public URL
- New project created and added to Confluence
- Docker file created for purpose
- Docker-compose.yaml for ease of local use

⚠️ I had to crank up the memory from 256 to 512 MB, otherwise the app was crashing

<img width="1374" alt="Screenshot 2023-02-14 at 19 58 05" src="https://user-images.githubusercontent.com/122792081/218985252-f2aaee3b-9111-4f4a-8606-59469ed971aa.png">




Next step: should we disable render.com?